### PR TITLE
[DRAFT] Speedup `combineTCR()` by removing sorting by barcode in a dataframe join

### DIFF
--- a/R/combineContigs.R
+++ b/R/combineContigs.R
@@ -65,11 +65,13 @@ combineTCR <- function(input.data,
                        filterNonproductive = TRUE) {
 
     # rudimentary input checking
-    assert_that(is.character(samples) || is.null(samples))
-    assert_that(is.character(ID) || is.null(ID))
-    assert_that(is.flag(removeNA))
-    assert_that(is.flag(removeMulti))
-    assert_that(is.flag(filterMulti))
+    assert_that(
+        is.character(samples) || is.null(samples),
+        is.character(ID) || is.null(ID),
+        is.flag(removeNA),
+        is.flag(removeMulti),
+        is.flag(filterMulti)
+    )
 
     input.data <- .checkList(input.data)
     input.data <- .checkContigs(input.data)
@@ -107,10 +109,10 @@ combineTCR <- function(input.data,
     for (i in seq_along(out)) {
         data2 <- .makeGenes(cellType = "T", out[[i]])
         Con.df <- .constructConDfAndParseTCR(data2)
-        Con.df <- .assignCT(cellType = "T", Con.df)
+        Con.df <- .assignCT(cellType = "T", Con.df) # the pasting in here is a tiny bit slow
         Con.df[Con.df == "NA_NA" | Con.df == "NA;NA_NA;NA"] <- NA
-        data3 <- merge(data2[,-which(names(data2) %in% c("TCR1","TCR2"))],
-            Con.df, by = "barcode")
+        data3 <- merge.data.frame(data2[,-which(names(data2) %in% c("TCR1","TCR2"))],
+            Con.df, by = "barcode", sort = FALSE)
       
         columns_to_include <- c("barcode")
         # Conditionally add columns based on user input

--- a/man/clonalRarefaction.Rd
+++ b/man/clonalRarefaction.Rd
@@ -37,8 +37,9 @@ coverage-based rarefaction/extrapolation curve (\code{type = 3}).}
 \item{hill.numbers}{The Hill numbers to be plotted out
 (0 - species richness, 1 - Shannon, 2 - Simpson)}
 
-\item{n.boots}{The number of bootstraps to downsample in order
-to get mean diversity.}
+\item{n.boots}{The number of bootstrap replicates used to derive confidence
+intervals for the diversity estimates. More replicates can provide a more
+reliable measure of statistical variability.}
 
 \item{exportTable}{Exports a table of the data into the global
 environment in addition to the visualization.}

--- a/man/loadContigs.Rd
+++ b/man/loadContigs.Rd
@@ -12,7 +12,7 @@ of pre-loaded contig data.}
 
 \item{format}{A string specifying the data format. Must be one of:
 "auto", "10X", "AIRR", "BD", "Dandelion", "JSON", "MiXCR", "ParseBio",
-"TRUST4", "WAT3R", or "Immcantation".If "auto", the function attempts
+"TRUST4", "WAT3R", or "Immcantation". If "auto", the function attempts
 automatic format detection.}
 }
 \value{

--- a/tests/testthat/helper-testingFunctions.R
+++ b/tests/testthat/helper-testingFunctions.R
@@ -1,5 +1,5 @@
 getdata <- function(dir, name) {
-	readRDS(paste("testdata/", dir, "/", name, ".rds", sep = "")) # could move testdata 1 dir lvl up nstead
+	readRDS(paste("testdata/", dir, "/", name, ".rds", sep = ""))
 }
 
 # shortcut get the combined contigs that are used in most testcases

--- a/tests/testthat/test-combineContigs.R
+++ b/tests/testthat/test-combineContigs.R
@@ -7,7 +7,7 @@ test_that("combineTCR works", {
 		input.data  = lapply(contig_list[1:3], head),
 		samples = c("P17B", "P17L", "P18B")
 	)
-	
+
 	expected1 <- getdata("combineContigs", "combineTCR_list_expected")
 	expect_identical(trial1, expected1)
 	
@@ -44,7 +44,6 @@ test_that("combineTCR works", {
 }) 
 
 # TODO combineTCR & combineBCR (need more edge cases, different args, errors, etc.)
-# TODO combineTCR for non-10x formats
 
 test_that("combineBCR works", {
 

--- a/tests/testthat/test-combineExpression.R
+++ b/tests/testthat/test-combineExpression.R
@@ -3,7 +3,7 @@
 test_that("combineExpression works with seurat objects", {
 	data("scRep_example")
 	combined <- getCombined()
-  combined_test <- combineExpression(combined, scRep_example)
+  	combined_test <- combineExpression(combined, scRep_example)
 	
 	#Seurat object test
 	expect_length(combined_test@meta.data, 13)


### PR DESCRIPTION
@ncborcherding During profiling of `combineTCR()` I noticed that a massive performance bottleneck is caused by a `merge` call on 2 dataframes, which in turns sorts the output dataframe by the `barcode` column. I simply disabled sorting and this in theory shouldn't affect anything else since its just the order of rows changing. However this has a small potential to break older scripts that worked with specific harcoded indices. Here are solutions to this:

1. Add an argument to enable/disable sorting that defaults to false
1. Just add documentation section telling users to manually sort everything if working on an old pipeline
1. Just optimize the sort

Let me know what you think.

Also at the time of submitting this PR draft I've been having issues with local testcases but as long as github CI passes it should be fine.